### PR TITLE
add support for nested input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .envrc
 .mypy_cache/
 .eggs/
+.idea

--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ query {
 """
 ```
 
+- Query with nested input
+
+```python
+from gql_query_builder import GqlQuery
+GqlQuery().fields(['name', 'height']).query('human', input={"input": {"data": {"id": "1000", "name": "test"}}}).operation().generate()
+"""
+query{
+    human(input: {data: {id: "1000", name: "test"}}){
+        human{
+            name, 
+            height
+        }
+    }
+}
+"""
+```
+
 - Query with input and arguments
 
 ```python

--- a/tests/test.py
+++ b/tests/test.py
@@ -19,6 +19,13 @@ class TestGqlQuery(TestCase):
         actual = GqlQuery().fields(['name', 'height']).query('human', input={"id": '"1000"'}).operation().generate()
         self.assertEqual(expected, actual)
 
+    def test_query_with_nested_input(self):
+        expected = 'query { human(input: {data: {id: "1000", name: "test"}}) { name height } }'
+        actual = GqlQuery().fields(['name', 'height']).query('human', input={
+            "input": {"data": {"id": "1000", "name": "test"}}}).operation().generate()
+        print(actual)
+        self.assertEqual(expected, actual)
+
     def test_query_input_with_arguments(self):
         expected = 'query { human(id: "1000") { name height(unit: FOOT) } }'
         actual = GqlQuery().fields(['name', 'height(unit: FOOT)']).query(
@@ -66,7 +73,8 @@ class TestGqlQuery(TestCase):
 
     def test_mutation(self):
         expected = 'mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) { createReview(episode: $ep, review: $review) { stars commentary } }'
-        actual = GqlQuery().fields(['stars', 'commentary']).query('createReview', input={"episode": "$ep", "review": "$review"}).operation(
+        actual = GqlQuery().fields(['stars', 'commentary']).query('createReview', input={"episode": "$ep",
+                                                                                         "review": "$review"}).operation(
             'mutation', name='CreateReviewForEpisode', input={"$ep": "Episode!", "$review": "ReviewInput!"}).generate()
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
Added support for nested inputs.  A good example of a query with nested input is: 

```
query{
    human(input: {data: {test: "test"}}){
        human{
            name, 
            height
        }
    }
}
```