### PR TITLE
Fix nested input with multiple args

### DIFF
--- a/gql_query_builder/__init__.py
+++ b/gql_query_builder/__init__.py
@@ -61,6 +61,8 @@ class GqlQuery():
 
         return final_str
 
+    
+
     def query(self, name: str, alias: str = '', input: Dict[str, Union[str, int]] = {}):
         self.query_field = name
         self.query_field = self.build_input(input, self.query_field)
@@ -97,3 +99,28 @@ class GqlQuery():
                 self.object = self.operation_field + ' { ' + self.query_field + ' ' + self.return_field + ' }'
 
         return self.remove_duplicate_spaces(self.object)
+
+
+def build_input_2(input: Dict[str, Union[str, int]], initial_str: str, nest= 0):
+    if(initial_str==''):
+        final_str = '('+initial_str
+    else: 
+        final_str = initial_str 
+    if(not bool(input)):
+        return final_str + ')'
+    key = list(input.keys())[0]
+    val = input[key]
+    if(not isinstance(val, dict)):
+        input.pop(key, {})
+        if(bool(input)):
+            final_str+=f" {key}: {val},"
+        else: 
+            if(nest >0):
+                final_str+=f" {key}: {val} " + " }" * nest
+            else: 
+                final_str+=f" {key}: {val}"
+        return build_input_2(input,final_str, nest)
+    else:
+        nest= nest+1
+        final_str+=f" {key}:" + ' {'
+        return build_input_2(val, final_str, nest)

--- a/gql_query_builder/__init__.py
+++ b/gql_query_builder/__init__.py
@@ -117,16 +117,16 @@ def build_input_2(input: Dict[str, Union[str, int]], initial_str: str, nest= 0, 
     if(not isinstance(val, dict)):
         input.pop(key, {})
         if(bool(input)):
-            final_str+=f" {key}: {val},"
+            final_str+=f' {key}: {val},'
         else: 
             if(nest >0):
-                final_str+=f" {key}: {val} " + " }" * nest
+                final_str+=f' {key}: "{val}" ' + ' }' * nest
             else: 
-                final_str+=f" {key}: {val}"
+                final_str+=f' {key}: "{val}"'
         return build_input_2(input,final_str, nest, other_input)
     else:
         nest= nest+1
-        final_str+=f" {key}:" + ' {'
+        final_str+=f' {key}:' + ' {'
         other_input = without_keys(input, key) 
         return build_input_2(val, final_str, nest, other_input)
 

--- a/gql_query_builder/__init__.py
+++ b/gql_query_builder/__init__.py
@@ -101,13 +101,17 @@ class GqlQuery():
         return self.remove_duplicate_spaces(self.object)
 
 
-def build_input_2(input: Dict[str, Union[str, int]], initial_str: str, nest= 0):
+def build_input_2(input: Dict[str, Union[str, int]], initial_str: str, nest= 0, other_input = {}):
     if(initial_str==''):
         final_str = '('+initial_str
     else: 
         final_str = initial_str 
     if(not bool(input)):
-        return final_str + ')'
+        if(bool(other_input)):
+            final_str = final_str + ','
+            return build_input_2(other_input, final_str, nest, {})
+        else:
+            return final_str + ')'
     key = list(input.keys())[0]
     val = input[key]
     if(not isinstance(val, dict)):
@@ -119,8 +123,12 @@ def build_input_2(input: Dict[str, Union[str, int]], initial_str: str, nest= 0):
                 final_str+=f" {key}: {val} " + " }" * nest
             else: 
                 final_str+=f" {key}: {val}"
-        return build_input_2(input,final_str, nest)
+        return build_input_2(input,final_str, nest, other_input)
     else:
         nest= nest+1
         final_str+=f" {key}:" + ' {'
-        return build_input_2(val, final_str, nest)
+        other_input = without_keys(input, key) 
+        return build_input_2(val, final_str, nest, other_input)
+
+def without_keys(d, keys):
+     return {x: d[x] for x in d if x not in keys}

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
-from gql_query_builder import GqlQuery
+
+from gql_query_builder import GqlQuery, build_input_2
 
 
 class TestGqlQuery(TestCase):
@@ -24,6 +25,15 @@ class TestGqlQuery(TestCase):
         actual = GqlQuery().fields(['name', 'height']).query('human', input={
             "input": {"data": {"id": "1000", "name": "test"}}}).operation().generate()
         self.assertEqual(expected, actual)
+
+    def test_x(self):
+        x = build_input_2({"where": {"id": 1}, "first": {"how": "justin"}}, "")
+        # x = build_input_2({"where": {"id":3, "name":"justin", "inside": {"what": 1}}, "first": 1}, "")
+        # x = build_input_2({"first":1,"where": {"id":3, "name":"justin", "inside": {"what": 1}}}, "")
+        # x = build_input_2({"where": {"id":3, "name":"justin"}}, "")
+        # x = build_input_2({"first": 1, "second":2 }, "")
+        print(x)
+
 
     def test_query_input_with_arguments(self):
         expected = 'query { human(id: "1000") { name height(unit: FOOT) } }'

--- a/tests/test.py
+++ b/tests/test.py
@@ -23,7 +23,6 @@ class TestGqlQuery(TestCase):
         expected = 'query { human(input: {data: {id: "1000", name: "test"}}) { name height } }'
         actual = GqlQuery().fields(['name', 'height']).query('human', input={
             "input": {"data": {"id": "1000", "name": "test"}}}).operation().generate()
-        print(actual)
         self.assertEqual(expected, actual)
 
     def test_query_input_with_arguments(self):


### PR DESCRIPTION
**Query**
```
GqlQuery().fields(['name', 'height']).query('human', input={"first": 1,"input": {"data": {"id": "1000", "name": "test"}}}).operation().generate()
```
**Current**
```
query { human(first: 1, input: {'data': {'id': '1000', 'name': 'test'}}) { name height } } 
```
**Expected**

Difference in `data` string

```
query { human(first: 1, input: {data: {'id': '1000', 'name': 'test'}}) { name height } } 
```