### PR TITLE
Throw an exception if fields are empty or null

### DIFF
--- a/gql_query_builder/__init__.py
+++ b/gql_query_builder/__init__.py
@@ -4,6 +4,10 @@
 from typing import Dict, List, Union
 
 
+class GqlQueryException(Exception):
+    pass
+
+
 class GqlQuery():
     def __init__(self) -> None:
         self.object: str = ''
@@ -16,6 +20,8 @@ class GqlQuery():
         return " ".join(query.split())
 
     def fields(self, fields: List, name: str = '', condition_expression: str = ''):
+        if not fields:
+            raise GqlQueryException('fields cannot be empty or null')
         query = '{ ' + " ".join(fields) + ' }'
         if name != '':
             if condition_expression != '':

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,14 +1,18 @@
 from unittest import TestCase
-from gql_query_builder import GqlQuery
+from gql_query_builder import GqlQuery, GqlQueryException
 
 
 class TestGqlQuery(TestCase):
+    def test_query_empty_fields(self):
+        with self.assertRaises(GqlQueryException):
+            GqlQuery().fields([]).query('hero').generate()
+
     def test_query_a_single_field(self):
         expected = 'query { hero { name } }'
         actual = GqlQuery().fields(['name']).query('hero').operation().generate()
         self.assertEqual(expected, actual)
 
-    def test_query_neting_fields(self):
+    def test_query_nesting_fields(self):
         expected = 'query { hero { name friends { name } } }'
         field_friends = GqlQuery().fields(['name'], name='friends').generate()
         actual = GqlQuery().fields(['name', field_friends]).query('hero').operation('query').generate()


### PR DESCRIPTION
Throw an exception if fields are empty or null to catch the issue early on, as this will not produce a valid GraphQL query.

Example (Before change)
```GqlQuery().fields([]).query('hero').generate()```
would produce an invalid GraphQL query: `hero { }`
